### PR TITLE
fixed event handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,14 @@
+# Change Log
+
+## 0.2.0
+
+- Modified Check\_MK handler script to add 'webhooks/st2' to URL.
+- Cast trace-tag as a string
+
+## 0.1.1
+
+- Metadata update only
+
+## 0.1.0
+
+- First release 

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
 - check_mk
 - monitoring
 - alerting
-version: 0.1.1
+version: 0.2.0
 author: codyaray
 email: talktome@codyaray.com


### PR DESCRIPTION
Updated event handler script to automatically add `webhooks/st2` to `st2_api_base_url`. 

Updated event handler to cast Trace-Tag UUID as a string.

Fixes #2 